### PR TITLE
Dp phone pageブランチをmainブランチにマージします

### DIFF
--- a/src/Components/PCpages/PCdp.tsx
+++ b/src/Components/PCpages/PCdp.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react"
+import { Footer } from "../Footer/Footer.tsx";
+import { Makingtab } from "../Header/Makingtab.tsx";
+import { Banner } from "../Header/Banner.tsx";
+import { PagesChangetag } from "../Header/PagesChange.tsx";
+
+export const PCdp = () => {
+    return (
+        <div>
+            <Makingtab />
+             <Banner />
+             <PagesChangetag />
+           <p>DPページです</p> 
+           <Footer />
+        </div>
+       )
+    
+};

--- a/src/Components/Pages/dp.tsx
+++ b/src/Components/Pages/dp.tsx
@@ -5,6 +5,7 @@ import { Banner } from "../Header/Banner.tsx";
 import { PagesChangetag } from "../Header/PagesChange.tsx";
 import spinerstyles from "../Loading/Loadingdots.module.css"
 import { Loadingsquares } from "../Loading/Loadingsquares.tsx";
+import { ResDp } from "../Responsivepages/ResDp.tsx";
 
 export const DP = () => {
 const [isVisable, setIsVisable] = useState(true);
@@ -17,14 +18,6 @@ const [isVisable, setIsVisable] = useState(true);
     return (
        isVisable ? (
          <Loadingsquares />
-       ) : (
-        <div>
-            <Makingtab />
-             <Banner />
-             <PagesChangetag />
-           <p>DPページです</p> 
-           <Footer />
-        </div>
-       )
+       ) : (<ResDp />)
     )
 };

--- a/src/Components/Phonepages/Phonepages/PhoneDp.tsx
+++ b/src/Components/Phonepages/Phonepages/PhoneDp.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { PhoneMakingtab } from '../PhoneHeader/PhoneMakingtab.tsx'
+import { PhoneBanner } from '../PhoneHeader/PhoneBanner.tsx'
+import { PhonePagesChange } from '../PhoneHeader/PhonePagesChange.tsx'
+import { PhoneFooter } from '../PhoneFooter/PhoneFooter.tsx'
+
+export const PhoneDp = () => {
+  return (
+    <div>
+       <PhoneMakingtab />
+       <PhoneBanner />
+       <PhonePagesChange />
+       <p>DPページです</p> 
+       <PhoneFooter />
+    </div>
+  )
+}

--- a/src/Components/Responsivepages/ResDp.tsx
+++ b/src/Components/Responsivepages/ResDp.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useMediaQuery } from 'react-responsive'
+import { PCdp } from '../PCpages/PCdp.tsx'
+import { PhoneDp } from '../Phonepages/Phonepages/PhoneDp.tsx'
+
+
+
+export const ResDp = () => {
+  const isDesktop: boolean = useMediaQuery({query: `(min-width: 414px)`})  
+  return (
+    <div>
+      {/*414px以上はデスクトップの画面*/}  
+      {isDesktop && <PCdp />}
+      {/*414px未満はモバイル用の画面*/}  
+      {!isDesktop && <PhoneDp />}
+    </div>
+  )
+}


### PR DESCRIPTION
##達成できたこと
・パソコン、スマートフォンに対応する画面とその表示を画面の幅や大きさによって変更するための
　ファイルを作った。

##反省点
　　簡単な作業であるが、以前mainブランチで作業をしてしまったため、コンフリクトやリバートなどの
　　なれない作業のせいでまた時間をとられてしまった。これからはその都度ブランチを切ること